### PR TITLE
Fix eval bug

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,10 +130,10 @@ python run_experiment.py \
 --conf_path conf/single/algorithms/1_pop_ml1m_conf.yml
 
 # SiBraR recommender ('sbnet' in code)
-python run_experiment.py 
---algorithm sbnet 
---dataset ml1m 
---split_type random 
+python run_experiment.py \
+--algorithm sbnet \
+--dataset ml1m \
+--split_type random \
 --conf_path conf/single/algorithms/sbnet_ml1m_conf.yml
 ```
 

--- a/eval/eval.py
+++ b/eval/eval.py
@@ -216,7 +216,7 @@ def evaluate_recommender_algorithm(alg: RecommenderAlgorithm, eval_loader: DataL
                 u_repr = alg.get_user_representations(u_idxs)
                 out = alg.combine_user_item_representations(u_repr, i_repr)
 
-                batch_mask = torch.tensor(dataset.exclude_data[u_idxs.cpu()].toarray(), dtype=torch.bool)
+                batch_mask = torch.tensor(dataset.exclude_data[u_idxs.cpu().numpy()].toarray(), dtype=torch.bool)
                 out[batch_mask] = -torch.inf
 
                 evaluator.eval_batch(u_idxs, out, labels)

--- a/eval/eval.py
+++ b/eval/eval.py
@@ -287,7 +287,7 @@ def gather_recommender_algorithm_results(alg: RecommenderAlgorithm, eval_loader:
 
             out = alg.predict(u_idxs, i_idxs)
 
-            batch_mask = torch.tensor(dataset.exclude_data[u_idxs.cpu()].toarray(), dtype=torch.bool)
+            batch_mask = torch.tensor(dataset.exclude_data[u_idxs.cpu().numpy()].toarray(), dtype=torch.bool)
             out[batch_mask] = -torch.inf
 
             if not isinstance(out, torch.Tensor):
@@ -313,7 +313,7 @@ def gather_recommender_algorithm_results(alg: RecommenderAlgorithm, eval_loader:
                 u_repr = alg.get_user_representations(u_idxs)
                 out = alg.combine_user_item_representations(u_repr, i_repr)
 
-                batch_mask = torch.tensor(dataset.exclude_data[u_idxs.cpu()].toarray(), dtype=torch.bool)
+                batch_mask = torch.tensor(dataset.exclude_data[u_idxs.cpu().numpy()].toarray(), dtype=torch.bool)
                 out[batch_mask] = -torch.inf
                 evaluator.eval_batch(u_idxs, out, labels)
 

--- a/eval/eval.py
+++ b/eval/eval.py
@@ -193,7 +193,7 @@ def evaluate_recommender_algorithm(alg: RecommenderAlgorithm, eval_loader: DataL
 
             out = alg.predict(u_idxs, i_idxs)
 
-            batch_mask = torch.tensor(dataset.exclude_data[u_idxs.cpu()].toarray(), dtype=torch.bool)
+            batch_mask = torch.tensor(dataset.exclude_data[u_idxs.cpu().numpy()].toarray(), dtype=torch.bool)
             out[batch_mask] = -torch.inf
 
             if not isinstance(out, torch.Tensor):


### PR DESCRIPTION
Hey! 

I just noticed that there was a .numpy() missing in the eval script. Adding it seems to fix the error `Attribut Error: ‘torch.dtype’ object has no attribute ‘type’` raised in the evaluation phase. @Tigxy could you check that this fix also works for you?
